### PR TITLE
Fix a compilation error when using GCC

### DIFF
--- a/lutf8lib.c
+++ b/lutf8lib.c
@@ -1872,7 +1872,7 @@ static int Lutf8_normalize_nfc(lua_State *L) {
   lua_pushboolean(L, 1); /* String was in normal form already, so 2nd return value is 'true' */
   return 2;
 
-build_string:
+build_string:;
   /* We will need to build a new string, this one is not NFC */
   luaL_Buffer buff;
   luaL_buffinit(L, &buff);


### PR DESCRIPTION
Before:

```sh
lutf8lib.c: In function 'Lutf8_normalize_nfc':
lutf8lib.c:1835:3: error: a label can only be part of a statement and a declaration is not a statement
 1835 |   luaL_Buffer buff;
      |   ^~~~~~~~~~~

```

```sh
cc -v
Using built-in specs.
COLLECT_GCC=cc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-linux-gnu/10/lto-wrapper
OFFLOAD_TARGET_NAMES=nvptx-none:amdgcn-amdhsa:hsa
OFFLOAD_TARGET_DEFAULT=1
Target: x86_64-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Debian 10.2.1-6' --with-bugurl=file:///usr/share/doc/gcc-10/README.Bugs --enable-languages=c,ada,c++,go,brig,d,fortran,objc,obj-c++,m2 --prefix=/usr --with-gcc-major-version-only --program-suffix=-10 --program-prefix=x86_64-linux-gnu- --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --enable-bootstrap --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-vtable-verify --enable-plugin --enable-default-pie --with-system-zlib --enable-libphobos-checking=release --with-target-system-zlib=auto --enable-objc-gc=auto --enable-multiarch --disable-werror --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --enable-multilib --with-tune=generic --enable-offload-targets=nvptx-none=/build/gcc-10-Km9U7s/gcc-10-10.2.1/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/gcc-10-Km9U7s/gcc-10-10.2.1/debian/tmp-gcn/usr,hsa --without-cuda-driver --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu --with-build-config=bootstrap-lto-lean --enable-link-mutex
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 10.2.1 20210110 (Debian 10.2.1-6) 

```

Reason:
https://stackoverflow.com/questions/18496282/why-do-i-get-a-label-can-only-be-part-of-a-statement-and-a-declaration-is-not-a

I assume other compilers are more permissive, but as it stands, commit 182575df130053b2097d3620896f223800bc2aa7 broke GCC support and the fuzzer tests.